### PR TITLE
Update openai.ts

### DIFF
--- a/lib/ai/openai.ts
+++ b/lib/ai/openai.ts
@@ -29,7 +29,7 @@ export interface ChatMessage {
  * `gpt-4o-mini` if no override is provided.
  */
 export function getDefaultModel(): string {
-  return process.env.OPENAI_MODEL || 'gpt-4o-mini';
+  return process.env.OPENAI_MODEL || 'gpt-5';
 }
 
 /**


### PR DESCRIPTION
feat: use GPT‑5 as default model