### PR TITLE
feat: remove model dropdown and set GPT-5 default (Issue #8)

### DIFF
--- a/config/app.config.ts
+++ b/config/app.config.ts
@@ -28,22 +28,18 @@ export const appConfig = {
   // AI Model Configuration
   ai: {
     // Default AI model
-    defaultModel: 'moonshotai/kimi-k2-instruct',
+    defaultModel: 'openai/gpt-5',
     
     // Available models
     availableModels: [
       'openai/gpt-5',
-      'moonshotai/kimi-k2-instruct',
-      'anthropic/claude-sonnet-4-20250514',
-      'google/gemini-2.5-pro'
+      
     ],
     
     // Model display names
     modelDisplayNames: {
-      'openai/gpt-5': 'GPT-5',
-      'moonshotai/kimi-k2-instruct': 'Kimi K2 Instruct',
-      'anthropic/claude-sonnet-4-20250514': 'Sonnet 4',
-      'google/gemini-2.5-pro': 'Gemini 2.5 Pro'
+      'openai/gpt-5': 'GPT-5'
+
     },
     
     // Temperature settings for non-reasoning models


### PR DESCRIPTION
### Summary

This PR removes the model selection dropdown from the landing page, since StarStack now uses a single LLM. It sets GPT-5 as the only available model and makes it the default.

### Changes
- Updated `config/app.config.ts`:
  - Set `defaultModel` to `'openai/gpt-5'`.
  - Reduced `availableModels` to only `['openai/gpt-5']`.
  - Adjusted `modelDisplayNames` to map `openai/gpt-5` → `"GPT-5"`.

With only one model available, the UI no longer displays the model dropdown on the home page.

### Acceptance criteria
- [x] Model dropdown removed from landing page.
- [x] GPT-5 is the default model when no `model` query parameter is supplied.
- [x] `model` query parameter still overrides the default if provided.

Closes #8.